### PR TITLE
Install libkfdwrapper64.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/roctx.h DESTINATION include )
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/roctracer_roctx.h DESTINATION include )
 install ( FILES ${PROJECT_BINARY_DIR}/so-roctx-link DESTINATION ../lib RENAME ${ROCTX_LIBRARY}.so )
 
+## kfdwrapper
+install ( TARGETS "kfdwrapper64" LIBRARY DESTINATION lib )
+
 ## Packaging directives
 set ( CPACK_GENERATOR "DEB" "RPM" "TGZ" )
 set ( CPACK_PACKAGE_NAME "${ROCTRACER_NAME}-dev" )


### PR DESCRIPTION
libkfdwrapper64.so is loaded by roctracer at run time. Currently, it is not installed to `CMAKE_INSTALL_PREFIX`. 