### PR TITLE
roctracer changes to support multiple ROCm installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ cmake_minimum_required ( VERSION 3.5.0 )
 ## Verbose output.
 set ( CMAKE_VERBOSE_MAKEFILE TRUE CACHE BOOL "Verbose Output" FORCE )
 
+# Install prefix
+set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
+
 ## Set module name and project name.
 set ( ROCTRACER_NAME "roctracer" )
 set ( ROCTRACER_TARGET "${ROCTRACER_NAME}64" )
@@ -43,17 +46,25 @@ include ( env )
 
 ## Setup the package version.
 get_version ( "1.0.0" )
-message ( "-- LIB-VERSION: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
 set ( BUILD_VERSION_MAJOR ${VERSION_MAJOR} )
 set ( BUILD_VERSION_MINOR ${VERSION_MINOR} )
 set ( BUILD_VERSION_PATCH ${VERSION_PATCH} )
-set ( LIB_VERSION_STRING "${BUILD_VERSION_MAJOR}.${BUILD_VERSION_MINOR}.${BUILD_VERSION_PATCH}" )
+
 if ( DEFINED VERSION_BUILD AND NOT ${VERSION_BUILD} STREQUAL "" )
   message ( "VERSION BUILD DEFINED ${VERSION_BUILD}" )
   set ( BUILD_VERSION_PATCH "${BUILD_VERSION_PATCH}-${VERSION_BUILD}" )
 endif ()
-set ( BUILD_VERSION_STRING "${BUILD_VERSION_MAJOR}.${BUILD_VERSION_MINOR}.${BUILD_VERSION_PATCH}" )
+
+set ( LIB_VERSION_MAJOR ${BUILD_VERSION_MAJOR} )
+set ( LIB_VERSION_MINOR ${BUILD_VERSION_MINOR} )
+if (DEFINED ENV{ROCM_LIBPATCH_VERSION})
+  set (LIB_VERSION_PATCH $ENV{ROCM_LIBPATCH_VERSION} )
+else ()
+  set (LIB_VERSION_PATCH ${BUILD_VERSION_PATCH} )
+endif()
+set ( LIB_VERSION_STRING "${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_PATCH}" )
+message ( "-- LIB-VERSION: ${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_PATCH}" )
 
 ## Set target and root/lib/test directory
 set ( TARGET_NAME "${ROCTRACER_TARGET}" )
@@ -66,7 +77,7 @@ include ( ${LIB_DIR}/CMakeLists.txt )
 
 ## Set the VERSION and SOVERSION values
 set_property ( TARGET ${TARGET_NAME} PROPERTY VERSION "${LIB_VERSION_STRING}" )
-set_property ( TARGET ${TARGET_NAME} PROPERTY SOVERSION "${BUILD_VERSION_MAJOR}" )
+set_property ( TARGET ${TARGET_NAME} PROPERTY SOVERSION "${LIB_VERSION_MAJOR}" )
 
 # If the library is a release, strip the target library
 if ( "${CMAKE_BUILD_TYPE}" STREQUAL release )
@@ -84,6 +95,10 @@ add_custom_target ( inc-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/include inc-link )
 add_custom_target ( so-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTRACER_LIBRARY}.so so-link )
+add_custom_target ( so-major-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTRACER_LIBRARY}.so.${LIB_VERSION_MAJOR} so-major-link )
+add_custom_target ( so-patch-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTRACER_LIBRARY}.so.${LIB_VERSION_STRING} so-patch-link )
 
 ## Install information
 install ( TARGETS ${ROCTRACER_TARGET} LIBRARY DESTINATION lib )
@@ -95,19 +110,31 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/ext/prof_protocol.h DESTINATION 
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/ext/hsa_rt_utils.hpp DESTINATION include/ext )
 install ( FILES ${PROJECT_BINARY_DIR}/inc-link DESTINATION ../include RENAME ${ROCTRACER_NAME} )
 install ( FILES ${PROJECT_BINARY_DIR}/so-link DESTINATION ../lib RENAME ${ROCTRACER_LIBRARY}.so )
+install ( FILES ${PROJECT_BINARY_DIR}/so-major-link DESTINATION ../lib RENAME ${ROCTRACER_LIBRARY}.so.${LIB_VERSION_MAJOR} )
+install ( FILES ${PROJECT_BINARY_DIR}/so-patch-link DESTINATION ../lib RENAME ${ROCTRACER_LIBRARY}.so.${LIB_VERSION_STRING} )
 install ( FILES ${PROJECT_BINARY_DIR}/test/libtracer_tool.so DESTINATION tool )
 
 ## rocTX
 set ( ROCTX_TARGET "roctx64" )
 set ( ROCTX_LIBRARY "lib${ROCTX_TARGET}" )
 
+## Set the VERSION and SOVERSION values
+set_property ( TARGET ${ROCTX_TARGET} PROPERTY VERSION "${LIB_VERSION_STRING}" )
+set_property ( TARGET ${ROCTX_TARGET} PROPERTY SOVERSION "${LIB_VERSION_MAJOR}" )
+
 add_custom_target ( so-roctx-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTX_LIBRARY}.so so-roctx-link )
+add_custom_target ( so-roctx-major-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTX_LIBRARY}.so.${LIB_VERSION_MAJOR} so-roctx-major-link )
+add_custom_target ( so-roctx-patch-link ALL WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink ../${ROCTRACER_NAME}/lib/${ROCTX_LIBRARY}.so.${LIB_VERSION_STRING} so-roctx-patch-link )
 
 install ( TARGETS "roctx64" LIBRARY DESTINATION lib )
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/roctx.h DESTINATION include )
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/inc/roctracer_roctx.h DESTINATION include )
 install ( FILES ${PROJECT_BINARY_DIR}/so-roctx-link DESTINATION ../lib RENAME ${ROCTX_LIBRARY}.so )
+install ( FILES ${PROJECT_BINARY_DIR}/so-roctx-major-link DESTINATION ../lib RENAME ${ROCTX_LIBRARY}.so.${LIB_VERSION_MAJOR} )
+install ( FILES ${PROJECT_BINARY_DIR}/so-roctx-patch-link DESTINATION ../lib RENAME ${ROCTX_LIBRARY}.so.${LIB_VERSION_STRING} )
 
 ## KFD wrapper
 if ( DEFINED KFD_WRAPPER )

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -3,7 +3,10 @@
 set -e
 
 do_ldconfig() {
-    echo /opt/rocm/roctracer/lib > /etc/ld.so.conf.d/libroctracer64.conf && ldconfig
+    INSTALL_PATH=/opt/rocm/roctracer
+    if [ -e "${INSTALL_PATH}" ] ; then
+        echo /opt/rocm/roctracer/lib > /etc/ld.so.conf.d/libroctracer64.conf && ldconfig
+    fi
 }
 
 case "$1" in

--- a/RPM/rpm_post
+++ b/RPM/rpm_post
@@ -1,1 +1,4 @@
-echo /opt/rocm/roctracer/lib > /etc/ld.so.conf.d/libroctracer64.conf && ldconfig
+INSTALL_PATH=/opt/rocm/roctracer
+if [ -e "${INSTALL_PATH}" ] ; then
+    echo /opt/rocm/roctracer/lib > /etc/ld.so.conf.d/libroctracer64.conf && ldconfig
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 SRC_DIR=`dirname $0`
 COMPONENT="roctracer"
-ROCM_PATH="/opt/rocm"
+ROCM_PATH="${ROCM_PATH:=/opt/rocm}"
+LD_RUNPATH_FLAG=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
 
 fatal() {
   echo "$1"
@@ -19,6 +20,7 @@ if [ -z "$PACKAGE_ROOT" ] ; then PACKAGE_ROOT=$ROCM_PATH; fi
 if [ -z "$PACKAGE_PREFIX" ] ; then PACKAGE_PREFIX="$ROCM_PATH/$COMPONENT"; fi
 if [ -z "$PREFIX_PATH" ] ; then PREFIX_PATH=$PACKAGE_ROOT; fi
 if [ -n "$HIP_VDI" ] ; then HIP_VDI_OPT="-DHIP_VDI=1"; fi
+if ! [ -z ${ROCM_RPATH+x} ] ; then LD_RUNPATH_FLAG=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"; fi
 
 ROCTRACER_ROOT=$(cd $ROCTRACER_ROOT && echo $PWD)
 MAKE_OPTS="-j 8 -C $BUILD_DIR"
@@ -33,6 +35,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$PACKAGE_ROOT \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$PACKAGE_PREFIX \
     -DCPACK_GENERATOR="DEB;RPM" \
+    -DCMAKE_SHARED_LINKER_FLAGS="$LD_RUNPATH_FLAG" \
     $HIP_VDI_OPT \
     $ROCTRACER_ROOT
 make


### PR DESCRIPTION
roctracer changes to support multiple ROCM installation

- Package is generated to install into ROCM_PATH by setting
      to CMAKE_INSTALL_PREFIX, if defined in the env otherwise
      default into /opt/rocm
- Lib SO version is added dependent on build version
- RUNPATH is set to a default value based on /opt/rocm and if
      ROCM_RPATH env is defined it is overwritten.
- Symlinks are created for library so files.
Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>