### PR TITLE
[Feature] Introduce a new API roctracer_get_timestamp().

### DIFF
--- a/inc/roctracer.h
+++ b/inc/roctracer.h
@@ -225,6 +225,10 @@ bool roctracer_load(
 
 void roctracer_unload(bool destruct);
 
+// Get system timestamp.
+roctracer_status_t roctracer_get_timestamp(
+    uint64_t* timestamp);
+
 #ifdef __cplusplus
 }  // extern "C" block
 #endif  // __cplusplus

--- a/src/core/roctracer.cpp
+++ b/src/core/roctracer.cpp
@@ -1106,6 +1106,12 @@ PUBLIC_API void roctracer_unload(bool destruct) {
   ONLOAD_TRACE_END();
 }
 
+PUBLIC_API roctracer_status_t roctracer_get_timestamp(uint64_t* timestamp) {
+  API_METHOD_PREFIX
+  *timestamp = util::HsaRsrcFactory::Instance().TimestampNs();
+  API_METHOD_SUFFIX
+}
+
 PUBLIC_API bool OnLoad(HsaApiTable* table, uint64_t runtime_version, uint64_t failed_tool_count,
                        const char* const* failed_tool_names) {
   ONLOAD_TRACE_BEG();


### PR DESCRIPTION
roctracer_status_t roctracer_get_timestamp(uint64_t* timestamp);

Get system timestamp for roctracer clients.

The API could be used to help roctracer clients understand the reference frame
of timestamps when receiving activity callbacks, as the nanoseconds reported in
the activity callbacks are not in the same reference frame as CPU walltime
clock.