### PR TITLE
Fix link time multiple definition problem 

### DIFF
--- a/inc/roctracer.h
+++ b/inc/roctracer.h
@@ -179,7 +179,7 @@ roctracer_status_t roctracer_open_pool_expl(
     const roctracer_properties_t* properties,             // tracer pool properties
     roctracer_pool_t** pool);                             // [out] returns tracer pool if not NULL,
                                                           // otherwise sets the default one if it is not set yet
-roctracer_status_t roctracer_open_pool(
+static inline roctracer_status_t roctracer_open_pool(
     const roctracer_properties_t* properties)             // tracer pool properties
 {
     return roctracer_open_pool_expl(properties, NULL);
@@ -189,7 +189,7 @@ roctracer_status_t roctracer_open_pool(
 // Close tracer memory pool
 roctracer_status_t roctracer_close_pool_expl(
     roctracer_pool_t* pool);                              // [in] memory pool, NULL is a default one
-roctracer_status_t roctracer_close_pool()
+static inline roctracer_status_t roctracer_close_pool()
 {
     return roctracer_close_pool_expl(NULL);
 }
@@ -198,7 +198,7 @@ roctracer_status_t roctracer_close_pool()
 // Set new default pool if the argument is not NULL
 roctracer_pool_t* roctracer_default_pool_expl(
     roctracer_pool_t* pool);                              // [in] new default pool if not NULL
-roctracer_pool_t* roctracer_default_pool()
+static inline roctracer_pool_t* roctracer_default_pool()
 {
     return roctracer_default_pool_expl(NULL);
 }
@@ -208,7 +208,7 @@ roctracer_status_t roctracer_enable_op_activity_expl(
     activity_domain_t domain,                             // tracing domain
     uint32_t op,                                          // activity op ID
     roctracer_pool_t* pool);                              // memory pool, NULL is a default one
-roctracer_status_t roctracer_enable_op_activity(
+static inline roctracer_status_t roctracer_enable_op_activity(
     activity_domain_t domain,                             // tracing domain
     uint32_t op)                                          // activity op ID
 {
@@ -217,14 +217,14 @@ roctracer_status_t roctracer_enable_op_activity(
 roctracer_status_t roctracer_enable_domain_activity_expl(
     activity_domain_t domain,                             // tracing domain
     roctracer_pool_t* pool);                              // memory pool, NULL is a default one
-roctracer_status_t roctracer_enable_domain_activity(
+static inline roctracer_status_t roctracer_enable_domain_activity(
     activity_domain_t domain)                             // tracing domain
 {
     return roctracer_enable_domain_activity_expl(domain, NULL);
 }
 roctracer_status_t roctracer_enable_activity_expl(
     roctracer_pool_t* pool);                       // memory pool, NULL is a default one
-roctracer_status_t roctracer_enable_activity()
+static inline roctracer_status_t roctracer_enable_activity()
 {
     return roctracer_enable_activity_expl(NULL);
 }
@@ -240,7 +240,7 @@ roctracer_status_t roctracer_disable_activity();
 // Flush available activity records
 roctracer_status_t roctracer_flush_activity_expl(
     roctracer_pool_t* pool);                              // memory pool, NULL is a default one
-roctracer_status_t roctracer_flush_activity()
+static inline roctracer_status_t roctracer_flush_activity()
 {
     return roctracer_flush_activity_expl(NULL);
 }


### PR DESCRIPTION
Using amd-master branch at a64f0538bbe1dd025210a63e7a01979f7fc527b0, I encountered the following linking error:

```
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_open_pool':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:184: multiple definition of `roctracer_open_pool'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:184: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_close_pool':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:193: multiple definition of `roctracer_close_pool'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:193: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_default_pool':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:202: multiple definition of `roctracer_default_pool'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:202: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_enable_op_activity':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:214: multiple definition of `roctracer_enable_op_activity'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:214: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_enable_domain_activity':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:222: multiple definition of `roctracer_enable_domain_activity'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:222: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_enable_activity':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:228: multiple definition of `roctracer_enable_activity'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:228: first defined here
gpu/amd/.libs/libhpcrun_la-roctracer-activity-translate.o: In function `roctracer_flush_activity':
/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:244: multiple definition of `roctracer_flush_activity'
sample-sources/.libs/libhpcrun_la-amd.o:/home/xm13/workspaces/rocm/roctracer/include/roctracer.h:244: first defined here
```

The root cause is that these functions are implemented in `roctracter.h` and these functions will be included in each compilation unit. At link time, there will be multiple definitions for the same function. One of the fix is to make these functions `static inline`.
