### PR TITLE
Support virtualenv/Anaconda Python environments

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories ( ${TARGET_LIB} PRIVATE ${LIB_DIR} ${ROOT_DIR} ${ROOT
 target_link_libraries( ${TARGET_LIB} PRIVATE ${HSA_RUNTIME_LIB} c stdc++ )
 
 # Generating HSA tracing primitives
-execute_process ( COMMAND sh -xc "${ROOT_DIR}/script/hsaap.py ${ROOT_DIR} ${HSA_RUNTIME_INC_PATH}" )
+execute_process ( COMMAND sh -xc "python ${ROOT_DIR}/script/hsaap.py ${ROOT_DIR} ${HSA_RUNTIME_INC_PATH}" )
 
 # Generating KFD/Thunk tracing primitives
 set ( KFD_LIB "kfdwrapper64" )
@@ -22,12 +22,12 @@ set ( KFD_LIB_SRC
   ${LIB_DIR}/kfd/kfd_wrapper.cpp
 )
 execute_process ( COMMAND sh -xc "${CMAKE_CXX_COMPILER} -E ${HSA_KMT_INC_PATH}/hsakmttypes.h > ${PROJECT_BINARY_DIR}/hsakmttypes_pp.h" )
-execute_process ( COMMAND sh -xc "${ROOT_DIR}/script/gen_ostream_ops.py -in ${PROJECT_BINARY_DIR}/hsakmttypes_pp.h -out ${ROOT_DIR}/inc/kfd_ostream_ops.h" )
-execute_process ( COMMAND sh -xc "${ROOT_DIR}/script/gen_ostream_ops.py -in ${HIP_PATH}/include/hip/hip_runtime_api.h -out ${ROOT_DIR}/inc/hip_ostream_ops.h" )
+execute_process ( COMMAND sh -xc "python ${ROOT_DIR}/script/gen_ostream_ops.py -in ${PROJECT_BINARY_DIR}/hsakmttypes_pp.h -out ${ROOT_DIR}/inc/kfd_ostream_ops.h" )
+execute_process ( COMMAND sh -xc "python ${ROOT_DIR}/script/gen_ostream_ops.py -in ${HIP_PATH}/include/hip/hip_runtime_api.h -out ${ROOT_DIR}/inc/hip_ostream_ops.h" )
 add_library ( ${KFD_LIB} SHARED ${KFD_LIB_SRC} )
 target_include_directories ( ${KFD_LIB} PRIVATE ${LIB_DIR} ${ROOT_DIR} ${ROOT_DIR}/inc ${HSA_RUNTIME_INC_PATH} ${HSA_RUNTIME_HSA_INC_PATH} ${HSA_KMT_INC_PATH} )
 target_link_libraries( ${KFD_LIB} PRIVATE c stdc++ )
-execute_process ( COMMAND sh -xc "${ROOT_DIR}/script/kfdap.py ${ROOT_DIR} ${HSA_KMT_INC_PATH}" )
+execute_process ( COMMAND sh -xc "python ${ROOT_DIR}/script/kfdap.py ${ROOT_DIR} ${HSA_KMT_INC_PATH}" )
 
 set ( ROCTX_LIB "roctx64" )
 set ( ROCTX_LIB_SRC


### PR DESCRIPTION
If trying to compile roctracer without root access, virtual environments may define their own Python binaries. Since CMake executes the .py files directly, the `#!` header enforces one binary to be executed.

This PR solves the problem by executing Python with the script as an argument.