### PR TITLE
Avoid empty-argument lists in C function declarations

### DIFF
--- a/inc/roctracer.h
+++ b/inc/roctracer.h
@@ -53,8 +53,8 @@ extern "C" {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Returning library version
-uint32_t roctracer_version_major();
-uint32_t roctracer_version_minor();
+uint32_t roctracer_version_major(void);
+uint32_t roctracer_version_minor(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Library errors enumaration
@@ -73,7 +73,7 @@ typedef enum {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Returning the last error
-const char* roctracer_error_string();
+const char* roctracer_error_string(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Traced runtime domains
@@ -126,7 +126,7 @@ roctracer_status_t roctracer_disable_op_callback(
     uint32_t op);                                         // API call ID
 roctracer_status_t roctracer_disable_domain_callback(
     activity_domain_t domain);                            // tracing domain
-roctracer_status_t roctracer_disable_callback();
+roctracer_status_t roctracer_disable_callback(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Activity API
@@ -236,7 +236,7 @@ roctracer_status_t roctracer_disable_op_activity(
     uint32_t op);                                         // activity op ID
 roctracer_status_t roctracer_disable_domain_activity(
     activity_domain_t domain);                            // tracing domain
-roctracer_status_t roctracer_disable_activity();
+roctracer_status_t roctracer_disable_activity(void);
 
 // Flush available activity records
 roctracer_status_t roctracer_flush_activity_expl(
@@ -251,9 +251,9 @@ roctracer_status_t roctracer_get_timestamp(
     uint64_t* timestamp);                                 // [out] return timestamp
 
 // Load/Unload methods
-bool roctracer_load();
-void roctracer_unload();
-void roctracer_flush_buf();
+bool roctracer_load(void);
+void roctracer_unload(void);
+void roctracer_flush_buf(void);
 
 // Set properties
 roctracer_status_t roctracer_set_properties(

--- a/inc/roctracer_ext.h
+++ b/inc/roctracer_ext.h
@@ -34,8 +34,8 @@ THE SOFTWARE.
 
 #include <roctracer.h>
 
-typedef void (*roctracer_start_cb_t)();
-typedef void (*roctracer_stop_cb_t)();
+typedef void (*roctracer_start_cb_t)(void);
+typedef void (*roctracer_stop_cb_t)(void);
 typedef struct {
   roctracer_start_cb_t start_cb;
   roctracer_stop_cb_t stop_cb;
@@ -49,10 +49,10 @@ extern "C" {
 // Application annotation API
 
 // Tracing start API
-void roctracer_start();
+void roctracer_start(void);
 
 // Tracing stop API
-void roctracer_stop();
+void roctracer_stop(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // External correlation id API

--- a/inc/roctx.h
+++ b/inc/roctx.h
@@ -44,12 +44,12 @@ extern "C" {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Returning library version
-uint32_t roctx_version_major();
-uint32_t roctx_version_minor();
+uint32_t roctx_version_major(void);
+uint32_t roctx_version_minor(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Returning the last error
-const char* roctracer_error_string();
+const char* roctracer_error_string(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Markers annotating API
@@ -68,7 +68,7 @@ int roctxRangePushA(const char* message);
 
 // Marks the end of a nested range.
 // A negative value is returned on the error.
-int roctxRangePop();
+int roctxRangePop(void);
 
 // ROCTX range id type
 typedef uint64_t roctx_range_id_t;


### PR DESCRIPTION
`()` as a function argument list in C is equivalent to `(...)`, i.e, in C
you get at most a warning, if it is called with too many arguments. Clarify
this situation by explicitly stating `(void)` as argument list.