### PR TITLE
Interface proposal : pull request 3

### DIFF
--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -352,21 +352,26 @@ void hsa_api_flush_cb(hsa_api_trace_entry_t* entry) {
   fprintf(hsa_api_file_handle, "%s\n", os.str().c_str()); fflush(hsa_api_file_handle);
 }
 
-void hsa_activity_callback(
-  uint64_t index,
-  uint32_t op,
-  uint32_t pid,
-  activity_record_t* record,
-  void* arg)
+struct hsa_activity_trace_entry_t {
+  uint64_t index;
+  uint32_t op;
+  uint32_t pid;
+  activity_record_t *record;
+  void *arg;
+};
+
+void hsa_activity_flush_cb(
+  hsa_activity_trace_entry_t *entry)
 {
-  fprintf(hsa_async_copy_file_handle, "%lu:%lu async-copy:%lu:%u\n", record->begin_ns, record->end_ns, index, pid); fflush(hsa_async_copy_file_handle);
+  fprintf(hsa_async_copy_file_handle, "%lu:%lu async-copy:%lu:%u\n", entry->record->begin_ns, entry->record->end_ns, entry->index, entry->pid); fflush(hsa_async_copy_file_handle);
 }
 
 void hsa_activity_callback_wrapper( uint32_t op,
   activity_record_t* record,
   void* arg){
   static uint64_t index = 0;
-  hsa_activity_callback(index, op, my_pid, record, arg);
+  hsa_activity_trace_entry_t hsa_activity_trace_entry = {index, op, my_pid, record, arg};
+  hsa_activity_flush_cb(&hsa_activity_trace_entry);
   index++;
   }
 


### PR DESCRIPTION
This is the third pull request for the proposal for a plugin interface for the rocprof command. In this pull request, the signatures of the flushing functions are standardized for every API/kind of event.

The signatures of all flushing functions are now of this kind : void _flush_cb(_trace_entry_t *entry)
Where is the kind of event or API that is traced and _trace_entry_t is a wrapping data structure containing the payloads of the traced events.

Relative to the second pull request, this one starts at commit 77d23b6