### PR TITLE
Interface proposal : pull request 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set ( PUBLIC_HEADERS
   roctracer_kfd.h
   roctracer_roctx.h
   roctracer_cb_table.h
+  roctracer_trace_entries.h
   ext/prof_protocol.h
   ext/hsa_rt_utils.hpp
 )

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -6,6 +6,7 @@
 
 #include <roctracer_roctx.h>
 #include <roctracer_hsa.h>
+#include <roctracer_hip.h>
 #include <ext/prof_protocol.h>
 #include <ext/hsa_rt_utils.hpp>
 
@@ -49,6 +50,20 @@ struct hsa_activity_trace_entry_t {
   uint32_t pid;
   activity_record_t *record;
   void *arg;
+};
+
+struct hip_api_trace_entry_t {
+  std::atomic<uint32_t> valid;
+  roctracer::entry_type_t type;
+  uint32_t domain;
+  uint32_t cid;
+  timestamp_t begin;
+  timestamp_t end;
+  uint32_t pid;
+  uint32_t tid;
+  hip_api_data_t data;
+  const char* name;
+  void* ptr;
 };
 
 #endif

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include <roctracer_roctx.h>
+#include <roctracer_hsa.h>
 #include <ext/hsa_rt_utils.hpp>
 
 typedef hsa_rt_utils::Timer::timestamp_t timestamp_t;
@@ -28,6 +29,17 @@ struct roctx_trace_entry_t {
   uint32_t tid;
   roctx_range_id_t rid;
   const char* message;
+};
+
+struct hsa_api_trace_entry_t {
+  std::atomic<uint32_t> valid;
+  roctracer::entry_type_t type;
+  uint32_t cid;
+  timestamp_t begin;
+  timestamp_t end;
+  uint32_t pid;
+  uint32_t tid;
+  hsa_api_data_t data;
 };
 
 #endif

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -1,0 +1,33 @@
+#ifndef INC_ROCTRACER_TRACE_ENTRIES_H_
+#define INC_ROCTRACER_TRACE_ENTRIES_H_
+
+#include <atomic>
+#include <cstdint>
+
+#include <roctracer_roctx.h>
+#include <ext/hsa_rt_utils.hpp>
+
+typedef hsa_rt_utils::Timer::timestamp_t timestamp_t;
+
+namespace roctracer {
+enum entry_type_t {
+  DFLT_ENTRY_TYPE = 0,
+  API_ENTRY_TYPE = 1,
+  COPY_ENTRY_TYPE = 2,
+  KERNEL_ENTRY_TYPE = 3,
+  NUM_ENTRY_TYPE = 4
+};
+}
+
+struct roctx_trace_entry_t {
+  std::atomic<uint32_t> valid;
+  roctracer::entry_type_t type;
+  uint32_t cid;
+  timestamp_t time;
+  uint32_t pid;
+  uint32_t tid;
+  roctx_range_id_t rid;
+  const char* message;
+};
+
+#endif

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -6,6 +6,7 @@
 
 #include <roctracer_roctx.h>
 #include <roctracer_hsa.h>
+#include <ext/prof_protocol.h>
 #include <ext/hsa_rt_utils.hpp>
 
 typedef hsa_rt_utils::Timer::timestamp_t timestamp_t;
@@ -40,6 +41,14 @@ struct hsa_api_trace_entry_t {
   uint32_t pid;
   uint32_t tid;
   hsa_api_data_t data;
+};
+
+struct hsa_activity_trace_entry_t {
+  uint64_t index;
+  uint32_t op;
+  uint32_t pid;
+  activity_record_t *record;
+  void *arg;
 };
 
 #endif

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -8,6 +8,7 @@
 #include <roctracer_roctx.h>
 #include <roctracer_hsa.h>
 #include <roctracer_hip.h>
+#include <roctracer_kfd.h>
 #include <ext/prof_protocol.h>
 #include <ext/hsa_rt_utils.hpp>
 
@@ -71,6 +72,18 @@ struct hip_activity_trace_entry_t {
   const roctracer_record_t *record;
   const char *name;
   uint32_t pid;
+};
+
+struct kfd_api_trace_entry_t {
+  std::atomic<uint32_t> valid;
+  roctracer::entry_type_t type;
+  uint32_t domain;
+  uint32_t cid;
+  timestamp_t begin;
+  timestamp_t end;
+  uint32_t pid;
+  uint32_t tid;
+  kfd_api_data_t data;
 };
 
 #endif

--- a/inc/roctracer_trace_entries.h
+++ b/inc/roctracer_trace_entries.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 
+#include <roctracer.h>
 #include <roctracer_roctx.h>
 #include <roctracer_hsa.h>
 #include <roctracer_hip.h>
@@ -64,6 +65,12 @@ struct hip_api_trace_entry_t {
   hip_api_data_t data;
   const char* name;
   void* ptr;
+};
+
+struct hip_activity_trace_entry_t {
+  const roctracer_record_t *record;
+  const char *name;
+  uint32_t pid;
 };
 
 #endif

--- a/src/core/trace_buffer.h
+++ b/src/core/trace_buffer.h
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <roctracer_trace_entries.h>
+
 #define FATAL(stream)                                                                              \
   do {                                                                                             \
     std::ostringstream oss;                                                                        \
@@ -34,14 +36,6 @@ enum {
   TRACE_ENTRY_INV = 0,
   TRACE_ENTRY_INIT = 1,
   TRACE_ENTRY_COMPL = 2
-};
-
-enum entry_type_t {
-  DFLT_ENTRY_TYPE = 0,
-  API_ENTRY_TYPE = 1,
-  COPY_ENTRY_TYPE = 2,
-  KERNEL_ENTRY_TYPE = 3,
-  NUM_ENTRY_TYPE = 4
 };
 
 struct trace_entry_t {

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -619,11 +619,6 @@ void hip_act_flush_cb(hip_act_trace_entry_t* entry) {
 
 // Activity tracing callback
 //   hipMalloc id(3) correlation_id(1): begin_ns(1525888652762640464) end_ns(1525888652762877067)
-struct hip_activity_trace_entry_t {
-  const roctracer_record_t *record;
-  const char *name;
-  uint32_t pid;
-};
 
 void hip_activity_flush_cb(hip_activity_trace_entry_t *entry){
   fprintf(hcc_activity_file_handle, "%lu:%lu %d:%lu %s:%lu:%u\n",

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -665,18 +665,6 @@ void pool_activity_callback(const char* begin, const char* end, void* arg) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // KFD API tracing
 
-struct kfd_api_trace_entry_t {
-  std::atomic<uint32_t> valid;
-  roctracer::entry_type_t type;
-  uint32_t domain;
-  uint32_t cid;
-  timestamp_t begin;
-  timestamp_t end;
-  uint32_t pid;
-  uint32_t tid;
-  kfd_api_data_t data;
-};
-
 void kfd_api_flush_cb(kfd_api_trace_entry_t* entry);
 constexpr roctracer::TraceBuffer<kfd_api_trace_entry_t>::flush_prm_t kfd_api_flush_prm = {roctracer::DFLT_ENTRY_TYPE, kfd_api_flush_cb};
 roctracer::TraceBuffer<kfd_api_trace_entry_t>* kfd_api_trace_buffer = NULL;

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -330,14 +330,6 @@ void hsa_api_flush_cb(hsa_api_trace_entry_t* entry) {
   fprintf(hsa_api_file_handle, "%s\n", os.str().c_str()); fflush(hsa_api_file_handle);
 }
 
-struct hsa_activity_trace_entry_t {
-  uint64_t index;
-  uint32_t op;
-  uint32_t pid;
-  activity_record_t *record;
-  void *arg;
-};
-
 void hsa_activity_flush_cb(
   hsa_activity_trace_entry_t *entry)
 {

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -348,20 +348,6 @@ void hsa_activity_callback_wrapper( uint32_t op,
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HIP API tracing
 
-struct hip_api_trace_entry_t {
-  std::atomic<uint32_t> valid;
-  roctracer::entry_type_t type;
-  uint32_t domain;
-  uint32_t cid;
-  timestamp_t begin;
-  timestamp_t end;
-  uint32_t pid;
-  uint32_t tid;
-  hip_api_data_t data;
-  const char* name;
-  void* ptr;
-};
-
 void hip_api_flush_cb(hip_api_trace_entry_t* entry);
 constexpr roctracer::TraceBuffer<hip_api_trace_entry_t>::flush_prm_t hip_api_flush_prm = {roctracer::DFLT_ENTRY_TYPE, hip_api_flush_cb};
 roctracer::TraceBuffer<hip_api_trace_entry_t>* hip_api_trace_buffer = NULL;

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -40,6 +40,7 @@ THE SOFTWARE.
 #include <roctracer_hcc.h>
 #include <roctracer_kfd.h>
 #include <ext/hsa_rt_utils.hpp>
+#include <roctracer_trace_entries.h>
 
 #include "src/core/loader.h"
 #include "src/core/trace_buffer.h"
@@ -97,7 +98,6 @@ inline static void DEBUG_TRACE(const char* fmt, ...) {
 inline static void DEBUG_TRACE(const char* fmt, ...) {}
 #endif
 
-typedef hsa_rt_utils::Timer::timestamp_t timestamp_t;
 hsa_rt_utils::Timer* timer = NULL;
 thread_local timestamp_t hsa_begin_timestamp = 0;
 thread_local timestamp_t hip_begin_timestamp = 0;
@@ -224,17 +224,6 @@ void* flush_thr_fun(void*) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // rocTX annotation tracing
-
-struct roctx_trace_entry_t {
-  std::atomic<uint32_t> valid;
-  roctracer::entry_type_t type;
-  uint32_t cid;
-  timestamp_t time;
-  uint32_t pid;
-  uint32_t tid;
-  roctx_range_id_t rid;
-  const char* message;
-};
 
 void roctx_flush_cb_wrapper(roctx_trace_entry_t* entry);
 constexpr roctracer::TraceBuffer<roctx_trace_entry_t>::flush_prm_t roctx_flush_prm = {roctracer::DFLT_ENTRY_TYPE, roctx_flush_cb_wrapper};

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -294,17 +294,6 @@ void roctx_flush_cb_wrapper(roctx_trace_entry_t* entry){
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HSA API tracing
 
-struct hsa_api_trace_entry_t {
-  std::atomic<uint32_t> valid;
-  roctracer::entry_type_t type;
-  uint32_t cid;
-  timestamp_t begin;
-  timestamp_t end;
-  uint32_t pid;
-  uint32_t tid;
-  hsa_api_data_t data;
-};
-
 void hsa_api_flush_cb(hsa_api_trace_entry_t* entry);
 constexpr roctracer::TraceBuffer<hsa_api_trace_entry_t>::flush_prm_t hsa_flush_prm = {roctracer::DFLT_ENTRY_TYPE, hsa_api_flush_cb};
 roctracer::TraceBuffer<hsa_api_trace_entry_t>* hsa_api_trace_buffer = NULL;

--- a/test/tool/tracer_tool.cpp
+++ b/test/tool/tracer_tool.cpp
@@ -352,21 +352,26 @@ void hsa_api_flush_cb(hsa_api_trace_entry_t* entry) {
   fprintf(hsa_api_file_handle, "%s\n", os.str().c_str()); fflush(hsa_api_file_handle);
 }
 
-void hsa_activity_callback(
-  uint64_t index,
-  uint32_t op,
-  uint32_t pid,
-  activity_record_t* record,
-  void* arg)
+struct hsa_activity_trace_entry_t {
+  uint64_t index;
+  uint32_t op;
+  uint32_t pid;
+  activity_record_t *record;
+  void *arg;
+};
+
+void hsa_activity_flush_cb(
+  hsa_activity_trace_entry_t *entry)
 {
-  fprintf(hsa_async_copy_file_handle, "%lu:%lu async-copy:%lu:%u\n", record->begin_ns, record->end_ns, index, pid); fflush(hsa_async_copy_file_handle);
+  fprintf(hsa_async_copy_file_handle, "%lu:%lu async-copy:%lu:%u\n", entry->record->begin_ns, entry->record->end_ns, entry->index, entry->pid); fflush(hsa_async_copy_file_handle);
 }
 
 void hsa_activity_callback_wrapper( uint32_t op,
   activity_record_t* record,
   void* arg){
   static uint64_t index = 0;
-  hsa_activity_callback(index, op, my_pid, record, arg);
+  hsa_activity_trace_entry_t hsa_activity_trace_entry = {index, op, my_pid, record, arg};
+  hsa_activity_flush_cb(&hsa_activity_trace_entry);
   index++;
   }
 


### PR DESCRIPTION
This is the fourth pull request for the proposal for a plugin interface for the rocprof command. In this pull request, the \<API\>_trace_entry_t structures defined in the previous pull requests have been moved to a new header.

Installation files have been modified to take into account this new header.
Some type definitions declared into headers that are not kept after installation are needed in the new header. To avoid the redeclaration of types, these types were moved from the place where they were first defined to this new header.

Relative to the third pull request, this one starts at commit 3787d72